### PR TITLE
Refactor code for consistent dialogue generation, pass shared bg slot via seperate var

### DIFF
--- a/source/components/PauseMenuComponent.cpp
+++ b/source/components/PauseMenuComponent.cpp
@@ -4,12 +4,15 @@
 
 // sfx
 #include "soundbank.h"
-
 // backgrounds
 #include "bgYukiClose.h"
 #include "bgGuard.h"
 #include "bgAkihiko.h"
 #include "bgYuki.h"
+// dialogue
+#include "dialogue/demo_dialogue.h"
+
+DialogueController dialogueCtrl;
 
 // add background setup here, and assign the bgLoader index to the appropriate PauseOption in PauseMenuComponent.h
 // NOTE: we can easily pass in custom bgLoaders. The reason I'm not implementing this behaviour is because I don't 
@@ -90,6 +93,12 @@ void PauseMenuComponent::init(int iBgSlot)
 
 ViewState PauseMenuComponent::update(int keys)
 {
+    // added for debug testing of dialogue
+    if (dialogueCtrl.isActive()) {
+        dialogueCtrl.update(keys);
+        return ViewState::KEEP_CURRENT;
+    }
+
     // navigate options
     if (keys & KEY_DOWN)
     {
@@ -113,6 +122,8 @@ ViewState PauseMenuComponent::update(int keys)
             ViewState result = (this->*(options[selectedOption].onSelect))();
             if (result != ViewState::KEEP_CURRENT) {
                 nextViewState = result;
+            } else if (dialogueCtrl.isActive()) {   // added for debug testing of dialogue
+                 return ViewState::KEEP_CURRENT;
             }
             // if we changed options, push current state to stack
             if (options != currentState.options)
@@ -264,6 +275,13 @@ ViewState PauseMenuComponent::debugOptionSelected()
             break;
         case IWATODAI_DORM_VIEW:
             selectedView = ViewState::IWATODAI_DORM;
+            break;
+        case DEBUG_DIALOGUE:
+            consoleClear();
+            demo_yuki_guard_argument_load();
+            dialogueCtrl.setLoader(demo_yuki_guard_argument_load_bg);
+            dialogueCtrl.start(demo_yuki_guard_argument_first());
+            selectedView = ViewState::KEEP_CURRENT;
             break;
         default:
             selectedView = ViewState::KEEP_CURRENT;

--- a/source/components/PauseMenuComponent.h
+++ b/source/components/PauseMenuComponent.h
@@ -12,7 +12,7 @@
 #define SYSTEM_OPTIONS 6
 
 // dummy option for testing
-#define DEBUG_OPTIONS 5
+#define DEBUG_OPTIONS 6
 # define SKILLS 2
 
 class PauseMenuComponent;
@@ -92,7 +92,8 @@ enum {
     INTRO_VIDEO_VIEW = 1,
     INTRO_VIEW = 2,
     MAIN_MENU_VIEW = 3,
-    IWATODAI_DORM_VIEW = 4
+    IWATODAI_DORM_VIEW = 4,
+    DEBUG_DIALOGUE = 5
 };
 
 class PauseMenuComponent {
@@ -137,6 +138,7 @@ class PauseMenuComponent {
             {"IntroView", -1, &PauseMenuComponent::debugOptionSelected},
             {"MainMenuView", -1, &PauseMenuComponent::debugOptionSelected},
             {"IwatodaiDormView", -1, &PauseMenuComponent::debugOptionSelected},
+            {"Debug Dialogue", -1, &PauseMenuComponent::debugOptionSelected},
         };
 
         // TODO: go into submenus

--- a/source/dialogue/demo_dialogue.cpp
+++ b/source/dialogue/demo_dialogue.cpp
@@ -5,9 +5,9 @@ int demo_dialogue_bg_slot = 0;
 
 // background import
 #include "bgAkihiko.h"
-#include "bgYukiClose.h"
 #include "bgGuard.h"
 #include "bgYuki.h"
+#include "bgYukiClose.h"
 
 void demo_unload() {
     bgHide(demo_dialogue_bg_slot);

--- a/source/dialogue/demo_dialogue.cpp
+++ b/source/dialogue/demo_dialogue.cpp
@@ -4,10 +4,10 @@
 int demo_dialogue_bg_slot = 0;
 
 // background import
-#include "bgYuki.h"
+#include "bgAkihiko.h"
 #include "bgYukiClose.h"
 #include "bgGuard.h"
-#include "bgAkihiko.h"
+#include "bgYuki.h"
 
 void demo_unload() {
     bgHide(demo_dialogue_bg_slot);

--- a/source/dialogue/demo_dialogue.cpp
+++ b/source/dialogue/demo_dialogue.cpp
@@ -3,11 +3,11 @@
 
 int demo_dialogue_bg_slot = 0;
 
-// ── BG imports ──────────────────────────────────────────────────────
-#include "bgYukiClose.h"
-#include "bgYuki.h"
+// background import
 #include "bgAkihiko.h"
+#include "bgYuki.h"
 #include "bgGuard.h"
+#include "bgYukiClose.h"
 
 void demo_unload() {
     bgHide(demo_dialogue_bg_slot);

--- a/source/dialogue/demo_dialogue.cpp
+++ b/source/dialogue/demo_dialogue.cpp
@@ -4,16 +4,16 @@
 int demo_dialogue_bg_slot = 0;
 
 // background import
-#include "bgAkihiko.h"
 #include "bgYuki.h"
-#include "bgGuard.h"
 #include "bgYukiClose.h"
+#include "bgGuard.h"
+#include "bgAkihiko.h"
 
 void demo_unload() {
     bgHide(demo_dialogue_bg_slot);
 }
 
-const char* demo_yuki_guard_argument_bg_names[4] = { "bgGuard", "bgYuki", "bgAkihiko", "bgYukiClose" };
+const char* demo_yuki_guard_argument_bg_names[4] = { "bgAkihiko", "bgGuard", "bgYuki", "bgYukiClose" };
 void (*demo_yuki_guard_argument_bg_loaders[4])() = {
     nullptr,
     nullptr,
@@ -28,6 +28,14 @@ void demo_yuki_guard_argument_load_bg(int bgIndex) {
 
 void demo_yuki_guard_argument_load() {
     demo_yuki_guard_argument_bg_loaders[0] = [](){
+        dmaCopy(bgAkihikoTiles, bgGetGfxPtr(demo_dialogue_bg_slot), bgAkihikoTilesLen);
+        dmaCopy(bgAkihikoMap, bgGetMapPtr(demo_dialogue_bg_slot), bgAkihikoMapLen);
+        vramSetBankH(VRAM_H_LCD);
+        dmaCopy(bgAkihikoPal, &VRAM_H_EXT_PALETTE[0][0], bgAkihikoPalLen);
+        vramSetBankH(VRAM_H_SUB_BG_EXT_PALETTE);
+        bgShow(demo_dialogue_bg_slot);
+    };
+    demo_yuki_guard_argument_bg_loaders[1] = [](){
         dmaCopy(bgGuardTiles, bgGetGfxPtr(demo_dialogue_bg_slot), bgGuardTilesLen);
         dmaCopy(bgGuardMap, bgGetMapPtr(demo_dialogue_bg_slot), bgGuardMapLen);
         vramSetBankH(VRAM_H_LCD);
@@ -35,19 +43,11 @@ void demo_yuki_guard_argument_load() {
         vramSetBankH(VRAM_H_SUB_BG_EXT_PALETTE);
         bgShow(demo_dialogue_bg_slot);
     };
-    demo_yuki_guard_argument_bg_loaders[1] = [](){
+    demo_yuki_guard_argument_bg_loaders[2] = [](){
         dmaCopy(bgYukiTiles, bgGetGfxPtr(demo_dialogue_bg_slot), bgYukiTilesLen);
         dmaCopy(bgYukiMap, bgGetMapPtr(demo_dialogue_bg_slot), bgYukiMapLen);
         vramSetBankH(VRAM_H_LCD);
         dmaCopy(bgYukiPal, &VRAM_H_EXT_PALETTE[0][0], bgYukiPalLen);
-        vramSetBankH(VRAM_H_SUB_BG_EXT_PALETTE);
-        bgShow(demo_dialogue_bg_slot);
-    };
-    demo_yuki_guard_argument_bg_loaders[2] = [](){
-        dmaCopy(bgAkihikoTiles, bgGetGfxPtr(demo_dialogue_bg_slot), bgAkihikoTilesLen);
-        dmaCopy(bgAkihikoMap, bgGetMapPtr(demo_dialogue_bg_slot), bgAkihikoMapLen);
-        vramSetBankH(VRAM_H_LCD);
-        dmaCopy(bgAkihikoPal, &VRAM_H_EXT_PALETTE[0][0], bgAkihikoPalLen);
         vramSetBankH(VRAM_H_SUB_BG_EXT_PALETTE);
         bgShow(demo_dialogue_bg_slot);
     };

--- a/source/views/IwatodaiDormView.cpp
+++ b/source/views/IwatodaiDormView.cpp
@@ -60,9 +60,9 @@ void IwatodaiDormView::Init() {
     glPolyFmt(POLY_ALPHA(31) | POLY_CULL_BACK);
     glColor3b(255, 255, 255);   // keep white so texture colors aren't tinted
 
-    // setup dialogue (sub screen)
-    demo_dialogue_bg_slot = bgInitSub(0, BgType_Text8bpp, BgSize_T_256x256, 0, 1);
-    dmaFillHalfWords(0, bgGetMapPtr(demo_dialogue_bg_slot), 2048);
+    // setup shared bg slot on sub screen
+    bgSharedSlot = bgInitSub(0, BgType_Text8bpp, BgSize_T_256x256, 0, 1);
+    dmaFillHalfWords(0, bgGetMapPtr(bgSharedSlot), 2048);
     
     // setup console
     consoleInit(&console, 1, BgType_Text4bpp, BgSize_T_256x256, 4, 5, false, true);
@@ -70,7 +70,7 @@ void IwatodaiDormView::Init() {
 
     // adjust sub screen image and console to sit correctly on each other
     bgSetPriority(console.bgId, 0);
-    bgSetPriority(demo_dialogue_bg_slot, 1);
+    bgSetPriority(bgSharedSlot, 1);
 
     bgUpdate();
 
@@ -92,6 +92,9 @@ void IwatodaiDormView::Init() {
         textureBitmap
     };
     iwatodaiDormEnv.load("nitro:/environments/iwatodai_dorm.bin", bitmaps);
+
+    // setup dialogue
+    demo_dialogue_bg_slot = bgSharedSlot;
 }
 
 ViewState IwatodaiDormView::Update() {

--- a/source/views/IwatodaiDormView.h
+++ b/source/views/IwatodaiDormView.h
@@ -37,6 +37,5 @@ class IwatodaiDormView : public View {
             const float angle = -1.6;
             const float characterFacingAngle = 91.67;
         DialogueController dialogueCtrl;
-            dialogue lines[5];
             int bgSharedSlot;
 };

--- a/source/views/IwatodaiDormView.h
+++ b/source/views/IwatodaiDormView.h
@@ -38,4 +38,5 @@ class IwatodaiDormView : public View {
             const float characterFacingAngle = 91.67;
         DialogueController dialogueCtrl;
             dialogue lines[5];
+            int bgSharedSlot;
 };

--- a/tools/converters/dlg2dialogue.py
+++ b/tools/converters/dlg2dialogue.py
@@ -278,7 +278,7 @@ class CodeGenerator:
         for ia in self.interactions:  
             for i, bg in enumerate(ia.bg_order):
                 bgSet.add(f'#include "{ia.bg_order[i] if ia.bg_order else "myBg"}.h"')
-        out.extend(list(bgSet))
+        out.extend(sorted(bgSet))
         out.append("")
         
         out += [

--- a/tools/converters/dlg2dialogue.py
+++ b/tools/converters/dlg2dialogue.py
@@ -268,7 +268,7 @@ class CodeGenerator:
             "",
             f"int {s}_dialogue_bg_slot = 0;",
             "",
-            "// ── BG imports ──────────────────────────────────────────────────────"
+            "// background import"
         ]
         bgSet = set()
         for ia in self.interactions:  

--- a/tools/converters/dlg2dialogue.py
+++ b/tools/converters/dlg2dialogue.py
@@ -198,6 +198,10 @@ class DialogueParser:
                 self.interactions.append(ia)
                 continue
             raise ParseError(n, f"Expected [interaction: name] or @bg directive, got: '{s}'")
+        # sort interactions, and each interaction's bg_order for consistent code output
+        self.interactions.sort()
+        for ia in self.interactions:
+            ia.bg_order.sort()
         return self.interactions
 
 class CodeGenerator:


### PR DESCRIPTION
- Updated IwatodaiDormView to use a bgSharedSlot var, and pass the value to dialogue code. This will allow the shared bg slot to be passed to other code in the future (note that the upcoming pause menu system will use this)
- Updated dlg2dialogue.py script to generate consistent code between "make" command runs. Previously, running "make" had a chance to change the _order_ of some code (no logical impact), resulting in useless difs.