### PR TITLE
Called cleanup() for environment on IwatodaiDormView

### DIFF
--- a/source/views/IntroView.cpp
+++ b/source/views/IntroView.cpp
@@ -344,6 +344,7 @@ void IntroView::Cleanup() {
     dmaFillHalfWords(0, bgGetMapPtr(bg[0]), 8192);  // silhouette
     dmaFillHalfWords(0, bgGetMapPtr(bg[3]), 8192);  // overlay
     // 256x256 backgrounds use 2048 bytes of map memory
+    // calculated using (256 / 8) * (256 / 8) * 2
     dmaFillHalfWords(0, bgGetMapPtr(bg[1]), 2048);  // room
     dmaFillHalfWords(0, bgGetMapPtr(bg[2]), 2048);  // sky
 

--- a/source/views/IwatodaiDormView.cpp
+++ b/source/views/IwatodaiDormView.cpp
@@ -216,13 +216,18 @@ void IwatodaiDormView::Cleanup()
     pauseMenu.cancelSFX();
     isPauseMenuActive = false;
 
+    // cleanup environment
+    iwatodaiDormEnv.cleanup();
     // reset textures
     glDeleteTextures(1, &characterTextureId);
+    // reset shared bg slot
+    dmaFillHalfWords(0, bgGetMapPtr(bgSharedSlot), 2048);
 
     // reset vram
     vramSetBankA(VRAM_A_LCD);
     vramSetBankB(VRAM_B_LCD);
     vramSetBankC(VRAM_C_LCD);
+    vramSetBankD(VRAM_D_LCD);
     vramSetBankH(VRAM_H_LCD);
 
     // cleanup controllers

--- a/source/views/IwatodaiStreetsView.cpp
+++ b/source/views/IwatodaiStreetsView.cpp
@@ -85,7 +85,7 @@ void IwatodaiStreetsView::Init() {
     glColor3b(255, 255, 255);
 
     // sub screen console
-    int bgSharedSlot = bgInitSub(0, BgType_Text8bpp, BgSize_T_256x256, 0, 1);
+    bgSharedSlot = bgInitSub(0, BgType_Text8bpp, BgSize_T_256x256, 0, 1);
     dmaFillHalfWords(0, bgGetMapPtr(bgSharedSlot), 2048);
     consoleInit(&console, 1, BgType_Text4bpp, BgSize_T_256x256, 4, 5, false, true);
     consoleSelect(&console);
@@ -213,6 +213,7 @@ void IwatodaiStreetsView::Cleanup() {
 
     iwatodaiStreetsEnv.cleanup();
     glDeleteTextures(1, &streetsCharacterTextureId);
+    dmaFillHalfWords(0, bgGetMapPtr(bgSharedSlot), 2048);
 
     vramSetBankA(VRAM_A_LCD);
     vramSetBankB(VRAM_B_LCD);

--- a/source/views/IwatodaiStreetsView.h
+++ b/source/views/IwatodaiStreetsView.h
@@ -12,6 +12,7 @@ class IwatodaiStreetsView : public View {
 
     private:
         PrintConsole console;
+        int bgSharedSlot;
 
         CharacterController* playerCtrl;
             cameraPosition camPos;


### PR DESCRIPTION
Previously by not calling cleanup(), this would cause an issue where the textures for IwatodaiDormView would not properly load the next time the View was rendered.

Also reset bank D memory in Dorm View to ensure the bank is clean for any scene after that uses it.

Reset bgSharedSlot in Dorm and Streets view on Cleanup().

Moved bgSharedSlot to .h file in Streets view for access in multiple functions.

Added comment in IntroView explaining how to calculate the bytes to clear.