### PR TITLE
38 Add VS Code GDB Debugger Support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,41 +2,36 @@
     "configurations": [
         {
             "name": "NDS",
+            "compilerPath": "${env:DEVKITPRO}/devkitARM/bin/arm-none-eabi-g++",
+            "intelliSenseMode": "gcc-arm",
             "forcedInclude": [
                 "${workspaceFolder}/include/vscode_fix.h"
             ],
             "includePath": [
-                "${workspaceFolder}",
                 "${workspaceFolder}/include/**",
-                "${DEVKITPRO}/devkitARM/arm-none-eabi/include/**",
-                "${DEVKITPRO}/libnds/include/**",
-                "${DEVKITPRO}/calico/include",
+                "${workspaceFolder}/source/**",
                 "${workspaceFolder}/build",
-                "${workspaceFolder}/source",
-                "${workspaceFolder}/source",
-                "${workspaceFolder}/source/core"
+                "${env:DEVKITPRO}/libnds/include/**",
+                "${env:DEVKITPRO}/devkitARM/arm-none-eabi/include/**",
+                "${env:DEVKITPRO}/calico/include"
             ],
             "defines": [
-                "_DEBUG",
-                "_UNICODE",
-                "WIN32",
-                "ARM7",
+                "__NDS__",
                 "ARM9",
-                "__NDS__"
+                "ENVIRONMENT_BUILD",
+                "_DEBUG"
             ],
             "browse": {
                 "path": [
-                    "${workspaceFolder}",
-                    "${workspaceFolder}/include/**",
-                    "${DEVKITPRO}/libnds/include/**",
-                    "${DEVKITPRO}/devkitARM/arm-none-eabi/include/**"
+                    "${workspaceFolder}/source",
+                    "${workspaceFolder}/include",
+                    "${env:DEVKITPRO}/libnds/include",
+                    "${env:DEVKITPRO}/devkitARM/arm-none-eabi/include"
                 ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
+                "limitSymbolsToIncludedHeaders": true
             },
             "cStandard": "c11",
-            "cppStandard": "c++11",
-            "compilerPath": "${DEVKITPRO}/devkitARM/bin/arm-none-eabi-g++"
+            "cppStandard": "c++17"
         }
     ],
     "version": 4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,8 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(gdb) Launch",
+            "name": "(gdb) Launch melonDS",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/${workspaceFolderBasename}.elf",
@@ -16,15 +13,37 @@
             "stopAtEntry": true,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": true,
+            "externalConsole": false,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:\\devkitPro\\devkitARM\\bin\\arm-none-eabi-gdb.exe",
-            "miDebuggerServerAddress": "localhost:20000",
+            // OS specific paths
+            "osx": {
+                "miDebuggerPath": "/opt/devkitpro/devkitARM/bin/arm-none-eabi-gdb"
+            },
+            "linux": {
+                "miDebuggerPath": "/opt/devkitpro/devkitARM/bin/arm-none-eabi-gdb"
+            },
+            "windows": {
+                "miDebuggerPath": "C:/devkitPro/devkitARM/bin/arm-none-eabi-gdb.exe"
+            },
+
+            "miDebuggerServerAddress": "localhost:2345",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing",
-                    "text": "file ${workspaceFolder}/${workspaceFolderBasename}.elf -enable-pretty-printing",
+                    "text": "-enable-pretty-printing",
                     "ignoreFailures": true
+                }
+            ],
+            "customLaunchSetupCommands": [
+                {
+                    "text": "target remote localhost:2345",
+                    "description": "Connect to melonDS",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "symbol-file ${workspaceFolder}/${workspaceFolderBasename}.elf",
+                    "description": "Force load symbols",
+                    "ignoreFailures": false
                 }
             ]
         }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+    // Search and UI cleanup
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "build/": true,
+        "*.elf": true,
+        "*.nds": true,
+        "*.map": true,
+        "**/*.d": true,
+        "**/*.o": true,
+    },
+
+    "search.exclude": {
+        "**/build": true,
+        "**/nitrofiles": true,
+        "**/*.d": true
+    },
+
+    // Formatting
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "editor.formatOnSave": true,
+
+    // C++ IntelliSense
+    "C_Cpp.intelliSenseEngine": "default",
+    "C_Cpp.formatting": "default",
+    "C_Cpp.errorSquiggles": "enabled",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,7 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -10,20 +11,7 @@
             "args": [
                 "DEBUG=1"
             ],
-            "problemMatcher": []
-        },
-        {
-            "label": "make release",
-            "type": "process",
-            "command": "make",
-            "args": [
-                "DEBUG=0"
-            ],
-            "problemMatcher": [],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
+            "problemMatcher": ["$gcc"]
         },
         {
             "label": "clean",
@@ -35,44 +23,38 @@
             "problemMatcher": []
         },
         {
-            "label": "run",
-            "type": "shell",
-            "isBackground": true,
-            "command": "C:\\desmume\\DeSmuME_0.9.11_x86.exe",
-            "args": [
-                "${workspaceFolder}/${workspaceFolderBasename}.nds"
-            ],
-            "presentation": {
-                "clear": true,
-                "reveal": "always"
-            },
-            "problemMatcher": []
-        },
-        {
             "label": "gdb-debug",
-            "type": "shell",
+            "type": "process",
+            // OS specific commands to launch melonDS
+            "windows": {
+                // For this to work, Windows needs to know where melonDS.exe lives.
+                // 1. Extract melonDS to a permanent folder (e.g., C:\Emulators\melonDS\)
+                // 2. Search Windows for "Environment Variables" -> Edit system environment variables.
+                // 3. Click "Environment Variables...", find "Path" in the top list, and click Edit.
+                // 4. Click New, paste your folder path, and hit OK.
+                // 5. RESTART VS CODE so it can see the new path.
+                "command": "melonDS",
+                "args": ["${workspaceFolder}/${workspaceFolderBasename}.nds"]
+            },
+            "linux": {
+                "command": "melonDS",
+                "args": ["${workspaceFolder}/${workspaceFolderBasename}.nds"]
+            },
+            "osx": {
+                "command": "open",
+                "args": ["-a", "melonDS", "${workspaceFolder}/${workspaceFolderBasename}.nds"]
+            },
             "dependsOn": [
                 "make debug"
             ],
-            "isBackground": false,
-            "command": "C:\\desmume\\DeSmuME_0.9.11_x86_dev+.exe",
-            "args": [
-                "--arm9gdb=20000",
-                "${workspaceFolder}/${workspaceFolderBasename}.nds"
-            ],
-            "presentation": {
-                "clear": true,
-                "reveal": "always"
-            },
             "problemMatcher": []
         },
         {
             "label": "stop-emulation",
-            "type": "shell",
-            "command": "taskkill",
+            "type": "process",
+            "command": "killall",
             "args": [
-                "/FI",
-                "imagename eq DeSmuME*"
+                "melonDS"
             ],
             "problemMatcher": []
         }

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ endif
 
 include $(DEVKITARM)/ds_rules
 
+# Default flags for release optimization
+OPT := -O3
+LTO_FLAG := -flto=auto
+
+ifeq ($(DEBUG), 1)
+    OPT := -O0 -g
+    LTO_FLAG :=
+endif
+
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
 # BUILD is the directory where object files & intermediate files will be placed
@@ -19,8 +28,8 @@ include $(DEVKITARM)/ds_rules
 #---------------------------------------------------------------------------------
 TARGET      :=  $(shell basename $(CURDIR))
 BUILD       :=  build
-SOURCES     :=  source source/views source/controllers source/core source/dialogue source/models source/environments source/components source/battleActions source/battleActions/enemies source/battleActions/party source/battleActions/skills 
-DATA        :=  
+SOURCES     :=  source source/views source/controllers source/core source/dialogue source/models source/environments source/components source/battleActions source/battleActions/enemies source/battleActions/party source/battleActions/skills
+DATA        :=
 INCLUDES    :=  include source
 
 # Add environment subdirectories directly to the GRAPHICS build pipeline
@@ -79,14 +88,12 @@ ENVIRONMENT_OUT := $(foreach file,$(ENV_OBJ_FILES),$(CURDIR)/source/environments
 #---------------------------------------------------------------------------------
 ARCH    :=  -march=armv5te -mtune=arm946e-s -mthumb
 
-CFLAGS  :=  -g -Wall -O3 -flto=auto -ffunction-sections -fdata-sections\
-        $(ARCH)
-
-CFLAGS  +=  $(INCLUDE) -DARM9
+CFLAGS  := $(OPT) $(ARCH) $(INCLUDE) -DARM9 -Wall $(LTO_FLAG) -ffunction-sections -fdata-sections
 CXXFLAGS    := $(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS :=  -g $(ARCH)
-LDFLAGS =   -specs=ds_arm9.specs -g $(ARCH) -flto=auto -Wl,--gc-sections -Wl,-Map,$(notdir $*.map)
+
+LDFLAGS =   -specs=ds_arm9.specs $(ARCH) $(LTO_FLAG) -Wl,--gc-sections -Wl,-Map,$(notdir $*.map)
 
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project

--- a/README.md
+++ b/README.md
@@ -30,14 +30,38 @@ The name is a nod to the online joke about a DS version of Persona 3 called "Per
 
 ---
 
-## Quick Setup
+## Developer Setup
 
-> Detailed setup instructions coming soon.
+### 1. Install System Dependencies
 
-1. Install [devkitPro](https://devkitpro.org/wiki/Getting_Started) with the DS toolchain
-2. Clone the repo
-3. `make` to build
-4. Load the `.nds` output in [melonDS](https://melonds.kuribo64.net/)
+**Windows:**
+1. Install [devkitPro](https://devkitpro.org/wiki/Getting_Started) using the official graphical installer (ensure `nds-dev` is checked).
+2. Install Python 3 from the [official website](https://www.python.org/downloads/) (Check "Add Python to PATH" during install).
+3. Install FFmpeg: Open Command Prompt or PowerShell and run `winget install ffmpeg`.
+4. Install [melonDS](https://melonds.kuribo64.net/downloads.php) (and optionally add melonDS to Path for debugger setup)
+
+**macOS:**
+1. Install [devkitPro](https://devkitpro.org/wiki/Getting_Started) via the official pacman pkg.
+2. Install Python and FFmpeg using Homebrew:
+   `brew install python ffmpeg`
+3. Install [melonDS](https://melonds.kuribo64.net/downloads.php)
+
+**Linux (Ubuntu/Debian):**
+1. Install devkitPro by following the [Unix-like platforms guide](https://devkitpro.org/wiki/Getting_Started#Unix-like_platforms).
+2. Install Python and FFmpeg:
+   `sudo apt update && sudo apt install python3 python3-venv ffmpeg`
+3. Install [melonDS](https://melonds.kuribo64.net/downloads.php)
+
+### 2. Setup the Project
+Once the system tools are installed, open your terminal, clone the repo, navigate to the project folder, and set up the Python environment:
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r tools/requirements.txt
+```
+
+You can then build a .nds rom by running ```make clean && make``` in the project folder.
 
 ---
 
@@ -117,6 +141,6 @@ See the [Project Board](https://github.com/users/TheBossT910/projects/2) for cur
 
 ## Inspiration
 
-Based on the **Persona 3** series of games (OG, FES, Portable, Reload), and inspired by the **Persona 3 Dual** online joke. 
+Based on the **Persona 3** series of games (OG, FES, Portable, Reload), and inspired by the **Persona 3 Dual** online joke.
 
 *This is a fan project and is not affiliated with or endorsed by Atlus or Sega.*


### PR DESCRIPTION
- Added GDB Debugger setup in VS Code for Windows, MacOS and Linux
- Only MacOS has been tested and confirmed working
- Also added dev setup instructions on README

To properly setup debugger on MelonDS:
1. Go to MelonDS settings
2. Click on the devtools tab
3. Enable GDB stub
4. Set the ARM9 port to "2345"
<img width="564" height="537" alt="image" src="https://github.com/user-attachments/assets/a56f6c9e-be1a-464c-9c24-624a3a5f28ee" />

**NOTE**: If you are on Windows and want to setup the debugger, you need to set an environment variable for MelonDS. The instructions are in .vscode/tasks.json
<img width="671" height="183" alt="image" src="https://github.com/user-attachments/assets/cd3e9619-60ae-4dfc-8a9b-9f3d236b17cf" />
