### PR TITLE
Load model in Iwatodai Dorm/Streets view

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -90,7 +90,6 @@ int main(int argc, char *argv[]) {
     mmInitDefaultMem((mm_addr)soundbank_bin);
 
     // setup character model
-    characterAnimationCtrl.loadModel("nitro:/models/character.bin");
     bitmapsCharacter[MODEL_CHARACTER_TEX_DISS_00] = diss_00Bitmap;
     bitmapsCharacter[MODEL_CHARACTER_TEX_DISS_01] = diss_01Bitmap;
     bitmapsCharacter[MODEL_CHARACTER_TEX_DISS_02] = diss_02Bitmap;

--- a/source/views/IwatodaiDormView.cpp
+++ b/source/views/IwatodaiDormView.cpp
@@ -74,6 +74,7 @@ void IwatodaiDormView::Init()
     musicCtrl.init(IWATODAI_DORM_MUSIC, 0.0f, -1.0f);
 
     // setup character model
+    characterAnimationCtrl.loadModel("nitro:/models/character.bin");
     character_loadTextures(characterAnimationCtrl, bitmapsCharacter);
 
     // setup environment model

--- a/source/views/IwatodaiStreetsView.cpp
+++ b/source/views/IwatodaiStreetsView.cpp
@@ -89,6 +89,7 @@ void IwatodaiStreetsView::Init() {
     musicCtrl.init(IWATODAI_STREETS_MUSIC, 0.0f, -1.0f);
 
     // setup character model
+    characterAnimationCtrl.loadModel("nitro:/models/character.bin");
     character_loadTextures(characterAnimationCtrl, bitmapsCharacter);
 
     // setup environment model


### PR DESCRIPTION
If loaded in main.cpp, we would get a malloc error from VideoController. It was also wasting memory as not all views needed to have the model loaded in