### PR TITLE
Correctly reset shared values after option select

### DIFF
--- a/source/components/BattleMenuComponent.cpp
+++ b/source/components/BattleMenuComponent.cpp
@@ -157,6 +157,8 @@ bool BattleMenuComponent::isAlertExpired(int durationFrames) const
 void BattleMenuComponent::reset()
 {
     loadedOption = BattleMenuOptions::NONE;
+    *isActivePtr = false;
+    pauseMessage = "";
     selectedOption = 0;
     startIndex = 0;
 }
@@ -177,7 +179,7 @@ ViewState BattleMenuComponent::update(int keys)
 // option handlers
 int BattleMenuComponent::battleOptionSelected()
 {
-    *isActivePtr = false;
-    pauseMessage = "";
-    return selectedOption;
+    int returnSelectedOption = selectedOption;
+    reset();
+    return returnSelectedOption;
 }


### PR DESCRIPTION
This fixes bugs where:
- selectedOption wasn't pointing at a valid option, causing a selection to crash the game
- selecting an option without any values (ex. SwitchPersona when characters cannot switch Persona) would reset the pauseMessage text