### PR TITLE
#170 added item db, reworked battlecalcs attack and healing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 #---------------------------------------------------------------------------------
 TARGET      :=  persona-3-dual
 BUILD       :=  build
-SOURCES := source source/views source/controllers source/core source/data source/dialogue source/models source/environments source/components source/battleActions source/battleActions/enemies source/battleActions/party source/battleActions/skills source/battleActions/actions source/helpers source/battleActions/armours source/battleActions/personas source/battleActions/shoes
+SOURCES := source source/views source/controllers source/core source/data source/dialogue source/models source/environments source/components source/battleActions source/battleActions/enemies source/battleActions/party source/battleActions/skills source/battleActions/actions source/helpers source/battleActions/armours source/battleActions/personas source/battleActions/shoes source/battleActions/weapons
 INCLUDES    :=  include source
 SFX         :=  assets/sfx
 

--- a/source/battleActions/BattleParticipant.h
+++ b/source/battleActions/BattleParticipant.h
@@ -28,4 +28,5 @@ struct BattleParticipant
     bool knockedDown = false;
 
     virtual BattleStats* getBattleStats() = 0;
+    virtual float calculateBaseDamage(BattleParticipant& defender, Skill& skill) = 0;
 };

--- a/source/battleActions/BattleParticipant.h
+++ b/source/battleActions/BattleParticipant.h
@@ -29,4 +29,5 @@ struct BattleParticipant
 
     virtual BattleStats* getBattleStats() = 0;
     virtual float calculateBaseDamage(BattleParticipant& defender, Skill& skill) = 0;
+    virtual float getTeamMultiplier() = 0;
 };

--- a/source/battleActions/WeaponType.h
+++ b/source/battleActions/WeaponType.h
@@ -1,0 +1,14 @@
+#pragma once
+
+enum class WeaponType
+{
+    OneHandedSword,
+    TwoHandedSword,
+    Bow,
+    Glove,
+    Rapier,
+    Gun,
+    Knive,
+    Axe,
+    Spear
+};

--- a/source/battleActions/enemies/Enemy.cpp
+++ b/source/battleActions/enemies/Enemy.cpp
@@ -58,3 +58,21 @@ BattleResult Enemy::resolve(BattleParticipant* target, Skill* skill)
 
     return {true, -(s32)damage, oneMoreResult, targetLog + skill->name};
 }
+
+float Enemy::calculateBaseDamage(BattleParticipant& defender, Skill& skill)
+{
+    u32 atk = BattleCalcs::getAtk(battleStats, skill);
+    float levelDifference = BattleCalcs::getLevelDifference(lv, defender.lv);
+    float affinityMtp = BattleCalcs::getAffinityMtp(*defender.getBattleStats(), skill);
+    if (skill.skillType == SkillType::RegularAttack)
+        return (sqrt((float)(skill.movePower * 6 * atk) /
+                     (8 * defender.getBattleStats()->en + defender.armour->defense)) *
+                9 * levelDifference) *
+               affinityMtp;
+    else if (skill.skillType == SkillType::Attack || skill.skillType == SkillType::MultiAttack)
+        return (
+            (sqrt((float)(skill.movePower * 6 * atk) / (8 * defender.getBattleStats()->en + defender.armour->defense)) *
+                 9 * levelDifference -
+             10) *
+            affinityMtp);
+}

--- a/source/battleActions/enemies/Enemy.cpp
+++ b/source/battleActions/enemies/Enemy.cpp
@@ -75,4 +75,11 @@ float Enemy::calculateBaseDamage(BattleParticipant& defender, Skill& skill)
                  9 * levelDifference -
              10) *
             affinityMtp);
+    else
+        return 0;
+}
+
+float Enemy::getTeamMultiplier()
+{
+    return 0.6f;
 }

--- a/source/battleActions/enemies/Enemy.h
+++ b/source/battleActions/enemies/Enemy.h
@@ -25,6 +25,7 @@ struct Enemy : BattleParticipant
     }
 
     float calculateBaseDamage(BattleParticipant& defender, Skill& skill) override;
+    float getTeamMultiplier() override;
 
     virtual ~Enemy() = default;
 };

--- a/source/battleActions/enemies/Enemy.h
+++ b/source/battleActions/enemies/Enemy.h
@@ -24,5 +24,7 @@ struct Enemy : BattleParticipant
         return &battleStats;
     }
 
+    float calculateBaseDamage(BattleParticipant& defender, Skill& skill) override;
+
     virtual ~Enemy() = default;
 };

--- a/source/battleActions/party/CharacterProfile.h
+++ b/source/battleActions/party/CharacterProfile.h
@@ -3,6 +3,7 @@
 #include "../personas/PersonaBase.h"
 #include "../shoes/Shoe.h"
 #include "../skills/Skill.h"
+#include "../weapons/Weapon.h"
 #include <nds.h>
 #include <vector>
 
@@ -19,6 +20,9 @@ struct CharacterProfile
     ArmourType armourType;
     Armour armour;
     Shoe shoe;
+
+    WeaponType weaponType;
+    Weapon weapon;
 
     Skill* baseAttackAction;
     std::vector<PersonaBase*> personas;

--- a/source/battleActions/party/CharacterProfileDb.cpp
+++ b/source/battleActions/party/CharacterProfileDb.cpp
@@ -3,6 +3,7 @@
 #include "../personas/PersonaDb.h"
 #include "../shoes/ShoeDb.h"
 #include "../skills/SkillDb.h"
+#include "../weapons/WeaponDb.h"
 
 CharacterProfile CharacterProfiles::player;
 CharacterProfile CharacterProfiles::yukari;
@@ -19,6 +20,8 @@ void CharacterProfiles::Initialize()
     player.lv = 2;
     player.participantType = ParticipantType::Player;
     player.armourType = ArmourType::Male;
+    player.weaponType = WeaponType::OneHandedSword;
+    player.weapon = WeaponDb::shortSword;
     player.baseAttackAction = &SkillDb::slashAttack;
     player.armour = ArmourDb::plainShirt;
     player.shoe = ShoeDb::rubberSole;
@@ -35,6 +38,8 @@ void CharacterProfiles::Initialize()
     yukari.lv = 1;
     yukari.participantType = ParticipantType::Party;
     yukari.armourType = ArmourType::Female;
+    yukari.weaponType = WeaponType::Bow;
+    yukari.weapon = WeaponDb::practiceBow;
     yukari.baseAttackAction = &SkillDb::pierceAttack;
     yukari.armour = ArmourDb::rashGuard;
     yukari.shoe = ShoeDb::rubberSole;
@@ -50,6 +55,8 @@ void CharacterProfiles::Initialize()
     junpei.lv = 1;
     junpei.participantType = ParticipantType::Party;
     junpei.armourType = ArmourType::Male;
+    junpei.weaponType = WeaponType::TwoHandedSword;
+    junpei.weapon = WeaponDb::imitationKatana;
     junpei.baseAttackAction = &SkillDb::slashAttack;
     junpei.armour = ArmourDb::rashGuard;
     junpei.shoe = ShoeDb::rubberSole;

--- a/source/battleActions/party/PartyMember.cpp
+++ b/source/battleActions/party/PartyMember.cpp
@@ -6,6 +6,6 @@ float PartyMember::calculateBaseDamage(BattleParticipant& defender, Skill& skill
     u32 atk = BattleCalcs::getAtk(curPersona->battleStats, skill);
     float levelDifference = BattleCalcs::getLevelDifference(lv, defender.lv);
     float affinityMtp = BattleCalcs::getAffinityMtp(*defender.getBattleStats(), skill);
-    floor(sqrt((float)(skill.movePower * 15 * atk) / defender.getBattleStats()->en) * 2 * levelDifference *
-          affinityMtp);
+    u32 movePower = (skill.skillType == SkillType::RegularAttack) ? (weapon.weaponPower / 2) : skill.movePower;
+    floor(sqrt((float)(movePower * 15 * atk) / defender.getBattleStats()->en) * 2 * levelDifference * affinityMtp);
 }

--- a/source/battleActions/party/PartyMember.cpp
+++ b/source/battleActions/party/PartyMember.cpp
@@ -7,5 +7,11 @@ float PartyMember::calculateBaseDamage(BattleParticipant& defender, Skill& skill
     float levelDifference = BattleCalcs::getLevelDifference(lv, defender.lv);
     float affinityMtp = BattleCalcs::getAffinityMtp(*defender.getBattleStats(), skill);
     u32 movePower = (skill.skillType == SkillType::RegularAttack) ? (weapon.weaponPower / 2) : skill.movePower;
-    floor(sqrt((float)(movePower * 15 * atk) / defender.getBattleStats()->en) * 2 * levelDifference * affinityMtp);
+    return floor(sqrt((float)(movePower * 15 * atk) / defender.getBattleStats()->en) * 2 * levelDifference *
+                 affinityMtp);
+}
+
+float PartyMember::getTeamMultiplier()
+{
+    return 1.0f;
 }

--- a/source/battleActions/party/PartyMember.cpp
+++ b/source/battleActions/party/PartyMember.cpp
@@ -1,0 +1,11 @@
+#include "PartyMember.h"
+#include "../skills/BattleCalcs.h"
+
+float PartyMember::calculateBaseDamage(BattleParticipant& defender, Skill& skill)
+{
+    u32 atk = BattleCalcs::getAtk(curPersona->battleStats, skill);
+    float levelDifference = BattleCalcs::getLevelDifference(lv, defender.lv);
+    float affinityMtp = BattleCalcs::getAffinityMtp(*defender.getBattleStats(), skill);
+    floor(sqrt((float)(skill.movePower * 15 * atk) / defender.getBattleStats()->en) * 2 * levelDifference *
+          affinityMtp);
+}

--- a/source/battleActions/party/PartyMember.h
+++ b/source/battleActions/party/PartyMember.h
@@ -4,6 +4,7 @@
 #include "../armours/Armour.h"
 #include "../personas/PersonaBase.h"
 #include "../shoes/Shoe.h"
+#include "../weapons/Weapon.h"
 #include "CharacterProfile.h"
 #include <nds.h>
 
@@ -12,6 +13,8 @@ struct PartyMember : BattleParticipant
     ArmourType* armourType;
     std::vector<PersonaBase*> personas;
     PersonaBase* curPersona;
+    WeaponType weaponType;
+    Weapon weapon;
 
     bool guarding = false;
 
@@ -32,6 +35,8 @@ struct PartyMember : BattleParticipant
         armourType = &characterProfile->armourType;
         armour = &characterProfile->armour;
         shoe = &characterProfile->shoe;
+        weaponType = characterProfile->weaponType;
+        weapon = characterProfile->weapon;
         personas = characterProfile->personas;
         curPersona = characterProfile->curPersona;
     }

--- a/source/battleActions/party/PartyMember.h
+++ b/source/battleActions/party/PartyMember.h
@@ -47,6 +47,7 @@ struct PartyMember : BattleParticipant
     }
 
     float calculateBaseDamage(BattleParticipant& defender, Skill& skill) override;
+    float getTeamMultiplier() override;
 
     ~PartyMember()
     {

--- a/source/battleActions/party/PartyMember.h
+++ b/source/battleActions/party/PartyMember.h
@@ -41,6 +41,8 @@ struct PartyMember : BattleParticipant
         return &curPersona->battleStats;
     }
 
+    float calculateBaseDamage(BattleParticipant& defender, Skill& skill) override;
+
     ~PartyMember()
     {
     }

--- a/source/battleActions/skills/BattleCalcs.cpp
+++ b/source/battleActions/skills/BattleCalcs.cpp
@@ -26,8 +26,9 @@ u32 BattleCalcs::attack(BattleParticipant& attacker, BattleParticipant& defender
                     affinityMtp);
     }
     else
+    {
         base = floor(sqrt((float)(skill.movePower * 15 * Atk) / defenderStats.en) * 2 * levelDifference * affinityMtp);
-
+    }
     float range = 95 + (u32)(rand() % 11);
     return std::clamp((u32)trunc(base * range / 100.0f), (u32)1, (u32)99999);
 }
@@ -96,40 +97,6 @@ u32 CalcHpDif::calculateDamageAllOutAttack(BattleStats* attackerStats,
 
 */
 
-void BattleCalcs::damageSetup(
-    BattleStats& attackerStats, BattleStats& defenderStats, u32& attackerLevel, u32& defenderLevel, Skill& skill)
-{
-    if (skill.skillRace == SkillRace::phys)
-        Atk = attackerStats.st;
-    else
-        Atk = attackerStats.ma;
-
-    // TODO: std clamp
-    diff = attackerLevel - defenderLevel;
-    if (diff < -13)
-        diff = -13;
-    else if (diff > 10)
-        diff = 10;
-
-    levelDifference = levelMultipliers[diff + 13]; // offset so -13 is 0
-
-    u32 affinity = defenderStats.affinities[(u32)skill.element];
-
-    if (affinity == BattleStats::Affinity::Weak)
-        affinityMtp = 1.25f;
-    else if (affinity == BattleStats::Affinity::Neutral)
-        affinityMtp = 1.0f;
-    else if (affinity == BattleStats::Affinity::Resist)
-        affinityMtp = 0.5f;
-    else if (affinity == BattleStats::Affinity::Null)
-        affinityMtp = 0.0f;
-    else if (affinity == BattleStats::Affinity::Absorb)
-        affinityMtp = -1.0f;
-    // TODO: add repel logic
-    else if (affinity == BattleStats::Affinity::Repel)
-        affinityMtp = -2.0f;
-}
-
 const float BattleCalcs::levelMultipliers[24] = {0.5f,  0.51f, 0.53f, 0.59f, 0.66f, 0.75f, 0.84f, 0.91f,
                                                  0.97f, 0.99f, 1.0f,  1.0f,  1.0f,  1.0f,  1.01f, 1.03f,
                                                  1.09f, 1.16f, 1.25f, 1.34f, 1.41f, 1.47f, 1.49f, 1.5f};
@@ -156,6 +123,45 @@ const float BattleCalcs::magicBoostTableHeal[20] = {
     125, // 91-95
     130  // 96-99
 };
+
+u32 BattleCalcs::getAtk(BattleStats& attackerStats, Skill& skill)
+{
+    if (skill.skillRace == SkillRace::phys)
+    {
+        return attackerStats.st;
+    }
+    else
+    {
+        return attackerStats.ma;
+    }
+}
+
+float BattleCalcs::getLevelDifference(u32 attackerLevel, u32 defenderLevel)
+{
+    s32 diff = attackerLevel - defenderLevel;
+    diff = std::clamp(diff, (s32)-13, (s32)10);
+
+    return levelMultipliers[diff + 13]; // offset so -13 is 0
+}
+
+float BattleCalcs::getAffinityMtp(BattleStats& defenderStats, Skill& skill)
+{
+    u32 affinity = defenderStats.affinities[(u32)skill.element];
+
+    if (affinity == BattleStats::Affinity::Weak)
+        return 1.25f;
+    else if (affinity == BattleStats::Affinity::Neutral)
+        return 1.0f;
+    else if (affinity == BattleStats::Affinity::Resist)
+        return 0.5f;
+    else if (affinity == BattleStats::Affinity::Null)
+        return 0.0f;
+    else if (affinity == BattleStats::Affinity::Absorb)
+        return -1.0f;
+    // TODO: add repel logic
+    else if (affinity == BattleStats::Affinity::Repel)
+        return -2.0f;
+}
 
 u32 BattleCalcs::getMagicBoostHeal(u32& magic)
 {

--- a/source/battleActions/skills/BattleCalcs.cpp
+++ b/source/battleActions/skills/BattleCalcs.cpp
@@ -4,7 +4,7 @@
 
 u32 BattleCalcs::attack(BattleParticipant& attacker, BattleParticipant& defender, Skill& skill)
 {
-    float base;
+    float base = attacker.calculateBaseDamage(defender, skill);
     float range = 95 + (u32)(rand() % 11);
     return std::clamp((u32)trunc(base * range / 100.0f), (u32)1, (u32)99999);
 }

--- a/source/battleActions/skills/BattleCalcs.cpp
+++ b/source/battleActions/skills/BattleCalcs.cpp
@@ -34,20 +34,8 @@ u32 BattleCalcs::hitrate(BattleParticipant& attacker, BattleParticipant& defende
 
 u32 BattleCalcs::healing(BattleParticipant& user, Skill& skill)
 {
-    float teamMultiplier;
-    BattleStats* battleStats;
-    if (user.participantType == ParticipantType::Party || user.participantType == ParticipantType::Player)
-    {
-        teamMultiplier = 1.0f;
-        PartyMember& partyMember = static_cast<PartyMember&>(user);
-        battleStats = &partyMember.curPersona->battleStats;
-    }
-    else
-    {
-        teamMultiplier = 0.6f;
-        Enemy& enemy = static_cast<Enemy&>(user);
-        battleStats = &enemy.battleStats;
-    }
+    BattleStats* battleStats = user.getBattleStats();
+    float teamMultiplier = user.getTeamMultiplier();
 
     u32 magicBoost = BattleCalcs::getMagicBoostHeal(battleStats->ma);
     u32 base = (u32)floor((skill.movePower + magicBoost) * teamMultiplier);
@@ -124,19 +112,22 @@ float BattleCalcs::getAffinityMtp(BattleStats& defenderStats, Skill& skill)
 {
     u32 affinity = defenderStats.affinities[(u32)skill.element];
 
-    if (affinity == BattleStats::Affinity::Weak)
+    switch (affinity)
+    {
+    case BattleStats::Affinity::Weak:
         return 1.25f;
-    else if (affinity == BattleStats::Affinity::Neutral)
-        return 1.0f;
-    else if (affinity == BattleStats::Affinity::Resist)
+    case BattleStats::Affinity::Resist:
         return 0.5f;
-    else if (affinity == BattleStats::Affinity::Null)
+    case BattleStats::Affinity::Null:
         return 0.0f;
-    else if (affinity == BattleStats::Affinity::Absorb)
+    case BattleStats::Affinity::Absorb:
         return -1.0f;
-    // TODO: add repel logic
-    else if (affinity == BattleStats::Affinity::Repel)
-        return -2.0f;
+    case BattleStats::Affinity::Repel:
+        return -2.0f; // TODO: add repel logic
+    case BattleStats::Affinity::Neutral:
+    default:
+        return 1.0f;
+    }
 }
 
 u32 BattleCalcs::getMagicBoostHeal(u32& magic)

--- a/source/battleActions/skills/BattleCalcs.cpp
+++ b/source/battleActions/skills/BattleCalcs.cpp
@@ -2,33 +2,9 @@
 #include "../enemies/Enemy.h"
 #include "../party/PartyMember.h"
 
-u32 BattleCalcs::Atk = 0;
-float BattleCalcs::affinityMtp = 0;
-s32 BattleCalcs::diff = 0;
-float BattleCalcs::levelDifference = 0;
-
 u32 BattleCalcs::attack(BattleParticipant& attacker, BattleParticipant& defender, Skill& skill)
 {
-    BattleStats& attackerStats = *attacker.getBattleStats();
-    BattleStats& defenderStats = *defender.getBattleStats();
-    BattleCalcs::damageSetup(attackerStats, defenderStats, attacker.lv, defender.lv, skill);
-    float base = 0;
-    if (attacker.participantType == ParticipantType::Enemy)
-    {
-        if (skill.skillType == SkillType::RegularAttack)
-            base = (sqrt((float)(skill.movePower * 6 * Atk) / (8 * defenderStats.en + defender.armour->defense)) * 9 *
-                    levelDifference) *
-                   affinityMtp;
-        else if (skill.skillType == SkillType::Attack || skill.skillType == SkillType::MultiAttack)
-            base = ((sqrt((float)(skill.movePower * 6 * Atk) / (8 * defenderStats.en + defender.armour->defense)) * 9 *
-                         levelDifference -
-                     10) *
-                    affinityMtp);
-    }
-    else
-    {
-        base = floor(sqrt((float)(skill.movePower * 15 * Atk) / defenderStats.en) * 2 * levelDifference * affinityMtp);
-    }
+    float base;
     float range = 95 + (u32)(rand() % 11);
     return std::clamp((u32)trunc(base * range / 100.0f), (u32)1, (u32)99999);
 }

--- a/source/battleActions/skills/BattleCalcs.h
+++ b/source/battleActions/skills/BattleCalcs.h
@@ -14,6 +14,10 @@ struct BattleCalcs
     static u32 hitrate(BattleParticipant& attacker, BattleParticipant& defender, Skill& skill);
     static u32 healing(BattleParticipant& user, Skill& skill);
 
+    static u32 getAtk(BattleStats& attackerStats, Skill& skill);
+    static float getLevelDifference(u32 attackerLevel, u32 defenderLevel);
+    static float getAffinityMtp(BattleStats& battleStats, Skill& skill);
+
     static u32 allOutAttack(BattleStats* attackerStats,
                             BattleStats* defenderStats,
                             u32* attackerLevel,
@@ -23,9 +27,6 @@ struct BattleCalcs
   private:
     //Attack
     static const float levelMultipliers[24];
-    static u32 getAtk(BattleStats& attackerStats, Skill& skill);
-    static float getLevelDifference(u32 attackerLevel, u32 defenderLevel);
-    static float getAffinityMtp(BattleStats& battleStats, Skill& skill);
 
     //Heal
     static const float magicBoostTableHeal[20];

--- a/source/battleActions/skills/BattleCalcs.h
+++ b/source/battleActions/skills/BattleCalcs.h
@@ -23,12 +23,9 @@ struct BattleCalcs
   private:
     //Attack
     static const float levelMultipliers[24];
-    static u32 Atk;
-    static float affinityMtp;
-    static s32 diff;
-    static float levelDifference;
-    static void damageSetup(
-        BattleStats& attackerStats, BattleStats& defenderStats, u32& attackerLevel, u32& defenderLevel, Skill& skill);
+    static u32 getAtk(BattleStats& attackerStats, Skill& skill);
+    static float getLevelDifference(u32 attackerLevel, u32 defenderLevel);
+    static float getAffinityMtp(BattleStats& battleStats, Skill& skill);
 
     //Heal
     static const float magicBoostTableHeal[20];

--- a/source/battleActions/skills/SkillDb.cpp
+++ b/source/battleActions/skills/SkillDb.cpp
@@ -14,7 +14,7 @@ Skill SkillDb::strikeAttack;
 void SkillDb::Initialize()
 {
     /*--------------REGULAR ATTACKS--------------*/
-    slashAttack.movePower = 10;
+    slashAttack.movePower = 15;
     slashAttack.element = Element::Slash;
     slashAttack.cost = 0;
     slashAttack.name = "Slash_Attack";
@@ -23,7 +23,7 @@ void SkillDb::Initialize()
     slashAttack.skillTarget = SkillTarget::OppositionTeam;
     slashAttack.skillType = SkillType::RegularAttack;
 
-    strikeAttack.movePower = 10;
+    strikeAttack.movePower = 15;
     strikeAttack.element = Element::Strike;
     strikeAttack.cost = 0;
     strikeAttack.name = "Strike_Attack";
@@ -32,7 +32,7 @@ void SkillDb::Initialize()
     strikeAttack.skillTarget = SkillTarget::OppositionTeam;
     strikeAttack.skillType = SkillType::RegularAttack;
 
-    pierceAttack.movePower = 10;
+    pierceAttack.movePower = 15;
     pierceAttack.element = Element::Pierce;
     pierceAttack.cost = 0;
     pierceAttack.name = "Pierce_Attack";

--- a/source/battleActions/weapons/Weapon.h
+++ b/source/battleActions/weapons/Weapon.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "../WeaponType.h"
+#include <nds.h>
+
+// TODO: we need some kind of selection and matching weaponType validation outside of battle
+// in the future
+struct Weapon
+{
+    u32 weaponPower;
+    WeaponType hitRate;
+    // TODO: add stat boosts / other shenanigans later
+};

--- a/source/battleActions/weapons/Weapon.h
+++ b/source/battleActions/weapons/Weapon.h
@@ -7,6 +7,7 @@
 struct Weapon
 {
     u32 weaponPower;
-    WeaponType hitRate;
+    u32 hitRate;
+    WeaponType weaponType;
     // TODO: add stat boosts / other shenanigans later
 };

--- a/source/battleActions/weapons/WeaponDb.cpp
+++ b/source/battleActions/weapons/WeaponDb.cpp
@@ -1,0 +1,18 @@
+#include "WeaponDb.h"
+Weapon WeaponDb::shortSword;
+Weapon WeaponDb::imitationKatana;
+
+void WeaponDb::Initialize()
+{
+    shortSword.weaponPower = 38;
+    shortSword.hitRate = 95;
+    shortSword.weaponType = WeaponType::OneHandedSword;
+
+    imitationKatana.weaponPower = 45;
+    imitationKatana.hitRate = 92;
+    imitationKatana.weaponType = WeaponType::TwoHandedSword;
+
+    imitationKatana.weaponPower = 30;
+    imitationKatana.hitRate = 98;
+    imitationKatana.weaponType = WeaponType::Bow;
+}

--- a/source/battleActions/weapons/WeaponDb.cpp
+++ b/source/battleActions/weapons/WeaponDb.cpp
@@ -1,6 +1,7 @@
 #include "WeaponDb.h"
 Weapon WeaponDb::shortSword;
 Weapon WeaponDb::imitationKatana;
+Weapon WeaponDb::practiceBow;
 
 void WeaponDb::Initialize()
 {

--- a/source/battleActions/weapons/WeaponDb.h
+++ b/source/battleActions/weapons/WeaponDb.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "Weapon.h"
+
+struct WeaponDb
+{
+    static Weapon shortSword;
+    static Weapon imitationKatana;
+    static Weapon practiceBow;
+
+    static void Initialize();
+};

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -47,6 +47,7 @@
 #include "battleActions/personas/PersonaDb.h"
 #include "battleActions/shoes/ShoeDb.h"
 #include "battleActions/skills/SkillDb.h"
+#include "battleActions/weapons/WeaponDb.h"
 
 // variables
 volatile int frame = 0;
@@ -194,6 +195,7 @@ int main(int argc, char* argv[])
     loadModels(saveData.femcMode);
 
     // setup db's. DO NOT CHANGE order
+    WeaponDb::Initialize();
     SkillDb::Initialize();
     ArmourDb::Initialize();
     ShoeDb::Initialize();


### PR DESCRIPTION
The obvious
- added weapon db
- added initzal weapons for Party members

now to the more interessting part. i wanted to somehow make a check if a regularattack was used and the attacker was a party member, which we have the participantType for so i could get the weapon value for the player.

Problem is were always casting, well more so why we are casting.

We have a baseclass, but assume diffrent behaviour depening on the child class. **_This is not maintainable_**. if we would add a boss type for example we would have to touch every single piece of code we ever check for types. 

So i did somethigns at least for the attack and heal calcs so we do not need to know the exact type.

this is a much larger issue and sometimes we have semi valid reasons for having ParticipantType, but i certainley wanna take a look at how we handle things regarding this in a few places where its not too much work.

This is not about abstracition, its about maintainability and saftey.

If you dont know it, the Liskov subsitution principle adresses this
https://objectmentor.com/resources/articles/lsp.pdf

i know this is 11 pages. i know this article is from 1998. So i dont expect you to read the whole thing (though i can only highly recommend it). The example on page 2 is a form of that violation, although we just use an enum in our case.
